### PR TITLE
fix: update install URLs to new repository

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 This project creates a terminal command called `claudectl` that allows users to manage multiple Anthropic account profiles for Claude Code CLI. It enables running different Claude sessions simultaneously, each with different account configurations, without setting global environment variables.
 
 **Platform Support**: macOS and Linux
-**Repository**: https://github.com/anthropics/claudectl
+**Repository**: https://github.com/jmif/claudectl
 
 ## Current Project Status (August 2025)
 
@@ -162,7 +162,7 @@ claudectl/
 
 ## Usage Workflow
 
-1. **Installation**: Use curl-based installer: `sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/anthropics/claudectl/main/install.sh)"`
+1. **Installation**: Use curl-based installer: `sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/jmif/claudectl/main/install.sh)"`
 2. **First run**: Creates hidden directory and settings file automatically
 3. **Daily use**: Run `claudectl`, select account profile, Claude launches with that config
 4. **Account Setup**: If account profile hasn't logged in, Claude Code will prompt for Anthropic login
@@ -214,7 +214,7 @@ claudectl/
 
 **Current Installation Method**: 
 ```bash
-sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/anthropics/claudectl/main/install.sh)"
+sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/jmif/claudectl/main/install.sh)"
 ```
 
 **Usage**: Simply run `claudectl` command to see interactive menu.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Perfect for developers, teams, consultants, and anyone juggling personal and pro
 
 For macOS & Linux:
 ```bash
-sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/anthropics/claudectl/main/install.sh)"
+sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/jmif/claudectl/main/install.sh)"
 ```
 
 Then just run:

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 BIN_NAME="claudectl"
-REPO_URL="https://raw.githubusercontent.com/anthropics/claudectl/main"
+REPO_URL="https://raw.githubusercontent.com/jmif/claudectl/main"
 USE_SUDO=false
 
 echo "Installing claudectl..."
@@ -67,4 +67,4 @@ else
     echo "       $BIN_NAME"
 fi
 echo
-echo "📚 Documentation: https://github.com/anthropics/claudectl"
+echo "📚 Documentation: https://github.com/jmif/claudectl"


### PR DESCRIPTION
## Summary
- point installer script at jmif/claudectl instead of anthropics/claudectl
- update README and CLAUDE docs with new jmif/claudectl installation link

## Testing
- `bash -n install.sh`
- `bash -n claudectl`
- `apt-get update` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_b_68b1a2792a2c8323a27a3cc8ad6a926c